### PR TITLE
Update path from .gz to .xz

### DIFF
--- a/scripts/10_download.sh
+++ b/scripts/10_download.sh
@@ -52,7 +52,7 @@ git clone https://aur.archlinux.org/1password-cli.git tmp/1password-cli
 # ```shell
 curl https://downloads.1password.com/linux/debian/amd64/stable/1password-latest.deb -o tmp/1password-latest.deb
 (cd tmp && ar x 1password-latest.deb)
-tar -C tmp -xf tmp/control.tar.gz ./postinst
+tar -C tmp -xf tmp/control.tar.xz ./postinst
 mkdir -p tmp/deb-data && tar -C tmp/deb-data -xf tmp/data.tar.xz
 #tree tmp/1password-8.10.28.x64/ > scripts/aur.tree
 #tree tmp/deb-data/ > scripts/deb.tree


### PR DESCRIPTION
Updates the path in the download script to reflect the current contents of the `.deb` file.

Closes #19 